### PR TITLE
proxy address と proxy port を設定できるようにする

### DIFF
--- a/lib/active_merchant/billing/gateways/epsilon.rb
+++ b/lib/active_merchant/billing/gateways/epsilon.rb
@@ -14,6 +14,8 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://www.example.net/'
       self.display_name = 'New Gateway'
 
+      # Allow access ActiveMerchant::Connection properties(proxy_address and proxy_port).
+      # see: https://github.com/Shopify/active_utils/blob/master/lib/active_utils/common/connection.rb#L34-L35
       cattr_accessor :contract_code, :proxy_address, :proxy_port
 
       PATHS = {
@@ -160,6 +162,8 @@ module ActiveMerchant #:nodoc:
         )
       end
 
+      # Override ActiveMerchant::PostsData#raw_ssl_request
+      # see: https://github.com/Shopify/active_utils/blob/master/lib/active_utils/common/posts_data.rb#L39
       def raw_ssl_request(method, endpoint, data, headers = {})
         logger.warn "#{self.class} using ssl_strict=false, which is insecure" if logger unless ssl_strict
 


### PR DESCRIPTION
@kenchan 
[Sqale](http://sqale.jp/)からイプシロンへpostする時にIPを指定する必要があるため、
プロキシサーバのアドレスとポートを設定できるようにしてみました。

``` ruby
irb(main):007:0> ActiveMerchant::Billing::EpsilonGateway.proxy_port = '8888'
=> "8888"
irb(main):029:0> ActiveMerchant::Billing::EpsilonGateway.proxy_address = 'httpproxy001.sqale.lan'
=> "httpproxy001.sqale.lan"
irb(main):032:0> gateway = ActiveMerchant::Billing::EpsilonGateway.new=> #<ActiveMerchant::Billing::EpsilonGateway:0x007f62a7831218 @options={}>
irb(main):033:0> gateway.proxy_address
=> "proxy.example.com"
irb(main):034:0> gateway.proxy_port
=> "8888"
irb(main):035:0> gateway.verify(credit_card, user_id: "U#{Time.now.to_i}", user_email: 'foo@example.com')
```
