### PR TITLE
Fix: uninitialized constant ActiveMerchant::Billing::Model (NameError)

### DIFF
--- a/lib/active_merchant/epsilon.rb
+++ b/lib/active_merchant/epsilon.rb
@@ -1,3 +1,4 @@
+require 'active_merchant'
 require_relative 'epsilon/version'
 require_relative 'billing/convenience_store'
 require_relative 'billing/gateways/epsilon'


### PR DESCRIPTION
@kenchan @kurotaky @kitak @takatoshiono @tsuchikazu 

I will try to resolve following problem:

(In application)
1. Just append this gem to Gemfile
2. bundle install
3. run test -> error!!

```
uninitialized constant ActiveMerchant::Billing::Model (NameError)
```
