### PR TITLE
number_of_payments を payment_time にリネームする

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,14 +139,14 @@ end
 # (snip)
 
 purchase_detail = {
-  user_id:            'YOUR_APP_USER_IDENTIFIER',
-  user_name:          '山田 太郎',
-  user_email:         'yamada-taro@example.com',
-  item_code:          'ITEM001',
-  item_name:          'Greate Product',
-  order_number:       'UNIQUE ORDER NUMBER',
-  credit_type:        ActiveMerchant::Billing::EpsilonGateway::CreditType::INSTALLMENT,
-  number_of_payments: 3, # 3, 5, 6, 10, 12, 15, 18, 20, 24
+  user_id:      'YOUR_APP_USER_IDENTIFIER',
+  user_name:    '山田 太郎',
+  user_email:   'yamada-taro@example.com',
+  item_code:    'ITEM001',
+  item_name:    'Greate Product',
+  order_number: 'UNIQUE ORDER NUMBER',
+  credit_type:  ActiveMerchant::Billing::EpsilonGateway::CreditType::INSTALLMENT,
+  payment_time: 3, # 3, 5, 6, 10, 12, 15, 18, 20, 24
 }
 
 # (snip)

--- a/lib/active_merchant/billing/gateways/epsilon.rb
+++ b/lib/active_merchant/billing/gateways/epsilon.rb
@@ -290,7 +290,7 @@ module ActiveMerchant #:nodoc:
             expire_y:       payment_method.year,
             expire_m:       payment_method.month,
             card_st_code:   detail[:credit_type],
-            pay_time:       detail[:number_of_payments],
+            pay_time:       detail[:payment_time],
             tds_check_code: detail[:three_d_secure_check_code],
           )
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -84,13 +84,13 @@ module SamplePaymentMethods
   def installment_purchase_detail
     now = Time.now
     {
-      user_id:            "U#{Time.now.to_i}",
-      user_email:         'yamada-taro@example.com',
-      item_code:          'ITEM001',
-      item_name:          'Greate Product',
-      order_number:       "O#{now.sec}#{now.usec}",
-      credit_type:        ActiveMerchant::Billing::EpsilonGateway::CreditType::INSTALLMENT,
-      number_of_payments: 3,
+      user_id:      "U#{Time.now.to_i}",
+      user_email:   'yamada-taro@example.com',
+      item_code:    'ITEM001',
+      item_name:    'Greate Product',
+      order_number: "O#{now.sec}#{now.usec}",
+      credit_type:  ActiveMerchant::Billing::EpsilonGateway::CreditType::INSTALLMENT,
+      payment_time: 3,
     }
   end
 


### PR DESCRIPTION
@takatoshiono @tsuchikazu @kitak @kenchan CC: @kurotaky 

number_of_payments を payment_time にリネームします
- それは number_of_payments が、単数形・複数形の区別・使い分けが難しいため
