### PR TITLE
月次課金の退会処理をできるようにした。

### DIFF
--- a/lib/active_merchant/billing/gateways/epsilon.rb
+++ b/lib/active_merchant/billing/gateways/epsilon.rb
@@ -14,6 +14,7 @@ module ActiveMerchant #:nodoc:
         registered_recurring: 'direct_card_payment.cgi',
         registered_purchase:  'direct_card_payment.cgi',
         cancel_recurring:     'receive_order3.cgi',
+        terminate_recurring:  'receive_order3.cgi',
         void:                 'cancel_payment.cgi',
         find_user:            'get_user_info.cgi',
       }.freeze
@@ -86,6 +87,17 @@ module ActiveMerchant #:nodoc:
         }
 
         commit(PATHS[:cancel_recurring], params)
+      end
+
+      def terminate_recurring(user_id:)
+        params = {
+          contract_code: self.contract_code,
+          user_id:       user_id,
+          xml:           1,
+          process_code:  9,
+        }
+
+        commit(PATHS[:terminate_recurring], params)
       end
 
       def find_user(user_id:)

--- a/test/fixtures/vcr_cassettes/terminate_recurring_fail.yml
+++ b/test/fixtures/vcr_cassettes/terminate_recurring_fail.yml
@@ -1,0 +1,96 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://beta.epsilon.jp/cgi-bin/order/direct_card_payment.cgi
+    body:
+      encoding: US-ASCII
+      string: contract_code=[CONTRACT_CODE]&user_id=U1433840422&user_name=YAMADA+Taro&user_mail_add=yamada-taro%40example.com&item_code=ITEM001&item_name=Greate+Product&order_number=O22389866&st_code=10000-0000-0000&mission_code=2&item_price=10000&process_code=1&card_number=4242424242424242&expire_y=2016&expire_m=10&card_st_code=&pay_time=&tds_check_code=&user_agent=ActiveMerchant%3A%3AEpsilon-0.5.0
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 09 Jun 2015 09:00:22 GMT
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=CP932
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="x-sjis-cp932"?>
+        <Epsilon_result>
+          <result acsurl="" />
+          <result err_code="" />
+          <result err_detail="" />
+          <result kari_flag="0" />
+          <result pareq="" />
+          <result result="1" />
+          <result trans_code="534678" />
+        </Epsilon_result>
+    http_version: 
+  recorded_at: Tue, 09 Jun 2015 09:00:23 GMT
+- request:
+    method: post
+    uri: https://beta.epsilon.jp/cgi-bin/order/receive_order3.cgi
+    body:
+      encoding: US-ASCII
+      string: contract_code=[CONTRACT_CODE]&user_id=U1433840422wrong&xml=1&process_code=9
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Tue, 09 Jun 2015 09:00:24 GMT
+      Server:
+      - Apache
+      Content-Length:
+      - '535'
+      Connection:
+      - close
+      Content-Type:
+      - text/html; charset=iso-8859-1
+    body:
+      encoding: UTF-8
+      string: |
+        <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+        <html><head>
+        <title>500 Internal Server Error</title>
+        </head><body>
+        <h1>Internal Server Error</h1>
+        <p>The server encountered an internal error or
+        misconfiguration and was unable to complete
+        your request.</p>
+        <p>Please contact the server administrator,
+         you@example.com and inform them of the time the error occurred,
+        and anything you might have done that may have
+        caused the error.</p>
+        <p>More information about this error may be available
+        in the server error log.</p>
+        </body></html>
+    http_version: 
+  recorded_at: Tue, 09 Jun 2015 09:00:24 GMT
+recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/terminate_recurring_successful.yml
+++ b/test/fixtures/vcr_cassettes/terminate_recurring_successful.yml
@@ -1,0 +1,82 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://beta.epsilon.jp/cgi-bin/order/direct_card_payment.cgi
+    body:
+      encoding: US-ASCII
+      string: contract_code=[CONTRACT_CODE]&user_id=U1433839922&user_name=YAMADA+Taro&user_mail_add=yamada-taro%40example.com&item_code=ITEM001&item_name=Greate+Product&order_number=O2281725&st_code=10000-0000-0000&mission_code=2&item_price=10000&process_code=1&card_number=4242424242424242&expire_y=2016&expire_m=10&card_st_code=&pay_time=&tds_check_code=&user_agent=ActiveMerchant%3A%3AEpsilon-0.5.0
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 09 Jun 2015 08:52:02 GMT
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=CP932
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="x-sjis-cp932"?>
+        <Epsilon_result>
+          <result acsurl="" />
+          <result err_code="" />
+          <result err_detail="" />
+          <result kari_flag="0" />
+          <result pareq="" />
+          <result result="1" />
+          <result trans_code="534647" />
+        </Epsilon_result>
+    http_version: 
+  recorded_at: Tue, 09 Jun 2015 08:52:03 GMT
+- request:
+    method: post
+    uri: https://beta.epsilon.jp/cgi-bin/order/receive_order3.cgi
+    body:
+      encoding: US-ASCII
+      string: contract_code=[CONTRACT_CODE]&user_id=U1433839922&xml=1&process_code=9
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 09 Jun 2015 08:52:03 GMT
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"x-sjis-cp932\" ?>\r\n  <Epsilon_result>\r\n
+        \   <result result=\"1\" />\r\n    <result user_id=\"U1433839922\" />\r\n
+        \   <result user_name=\"YAMADA%20Taro\" />\r\n    <result memo1=\"\" />\r\n
+        \   <result memo2=\"\" />\r\n </Epsilon_result>\r\n"
+    http_version: 
+  recorded_at: Tue, 09 Jun 2015 08:52:04 GMT
+recorded_with: VCR 2.9.3

--- a/test/remote/gateways/remote_epsilon_test.rb
+++ b/test/remote/gateways/remote_epsilon_test.rb
@@ -141,6 +141,27 @@ class RemoteEpsilonGatewayTest < MiniTest::Test
     end
   end
 
+  def test_terminate_recurring
+    VCR.use_cassette(:terminate_recurring_successful) do
+      detail = purchase_detail
+      response = gateway.recurring(10000, valid_credit_card, detail)
+      assert_equal true, response.success?
+      response = gateway.terminate_recurring(user_id: detail[:user_id])
+      assert_equal true, response.success?
+    end
+  end
+
+  def test_terminate_recurring_fail
+    VCR.use_cassette(:terminate_recurring_fail) do
+      detail = purchase_detail
+      response = gateway.recurring(10000, valid_credit_card, detail)
+      assert_equal true, response.success?
+      assert_raises(ActiveMerchant::ResponseError) do
+        gateway.terminate_recurring(user_id: detail[:user_id] + 'wrong')
+      end
+    end
+  end
+
   def test_void
     VCR.use_cassette(:void_successful) do
       detail = purchase_detail


### PR DESCRIPTION
@inouetakuya @takatoshiono @tsuchikazu @kitak @kenchan
月次課金の退会(process_code: 9)をできるようにしました。

API側の仕様に関してはイプシロンのCGI設定マニュアル2.0.25 p.59の
送信パラメータ、戻りパラメータの表をご参照下さい。
