### PR TITLE
コンビニ決済のサンプルコードにタイポがあったので修正する

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ gateway = ActiveMerchant::Billing::EpsilonConvenienceStoreGateway.new
 convenience_store = ActiveMerchant::Billing::ConvenienceStore.new(
   code:           ActiveMerchant::Billing::ConvenienceStore::Code::LAWSON,
   full_name_kana: 'ヤマダ タロウ',
-  phone_nubmer:   '0312345678'
+  phone_number:   '0312345678'
 )
 
 purchase_detail = {


### PR DESCRIPTION
@takatoshiono @tsuchikazu @kenchan @kurotaky

コンビニ決済のサンプルコードにタイポがあって、
そのままコピーして実行すると

```
ArgumentError: missing keyword: phone_number
```

となるので修正しました。