### PR TITLE
added url of epsilon official site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Gem](https://img.shields.io/gem/v/active_merchant-epsilon.svg?style=flat-square)](https://rubygems.org/gems/active_merchant-epsilon)
 [![wercker status](https://app.wercker.com/status/43c6648e20f325c8c0a560c36e89781c/s/master "wercker status")](https://app.wercker.com/project/bykey/43c6648e20f325c8c0a560c36e89781c)
 
-Epsilon integration for ActiveMerchant.
+[Epsilon](http://www.epsilon.jp/) integration for ActiveMerchant.
 
 ## Installation
 


### PR DESCRIPTION
There is no url of service url on README. I added it :octocat: 