### PR TITLE
モジュール名CodeをつけないとNameErrorになるのでvalid_code?の中の定数にモジュール名をつける

### DIFF
--- a/lib/active_merchant/billing/convenience_store.rb
+++ b/lib/active_merchant/billing/convenience_store.rb
@@ -48,7 +48,7 @@ module ActiveMerchant
       end
 
       def valid_code?(code)
-        [SEVEN_ELEVEN, FAMILY_MART, LAWSON, SEICO_MART].include?(code.to_i)
+        [Code::SEVEN_ELEVEN, Code::FAMILY_MART, Code::LAWSON, Code::SEICO_MART].include?(code.to_i)
       end
     end
   end


### PR DESCRIPTION
@kurotaky @inouetakuya 
`lib/active_merchant/billing/convenience_store.rb` 内の `valid_code?` メソッドで
コンビニのコードを表す定数にモジュール名がついていなかったため、
`NameError`になっていたので、モジュール名をつけます。