### PR TITLE
Fix response parser method

### DIFF
--- a/lib/active_merchant/billing/gateways/response_parser.rb
+++ b/lib/active_merchant/billing/gateways/response_parser.rb
@@ -70,7 +70,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def company_code
-        @xml.xpath(@xml.xpath(ResponseXpath::COMPANY_CODE).to_s)
+        @xml.xpath(ResponseXpath::COMPANY_CODE).to_s
       end
 
       def uri_decode(string)


### PR DESCRIPTION
ref: https://github.com/pepabo/active_merchant-epsilon/pull/80#issuecomment-205142757

This convenience payment response doesn't parsed correctly.

I remove one code `@xml.xpath` to correct this problem.