### PR TITLE
Add encoding setting

### DIFF
--- a/active_merchant-epsilon.gemspec
+++ b/active_merchant-epsilon.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'tapp'
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'vcr'
+  spec.add_development_dependency 'mocha'
 end

--- a/lib/active_merchant/billing/gateways/epsilon/epsilon_base.rb
+++ b/lib/active_merchant/billing/gateways/epsilon/epsilon_base.rb
@@ -72,8 +72,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def encode_value(value)
-        return value unless self.encoding
-        value.encode(self.encoding, invalid: :replace, undef: :replace)
+        return value unless encoding
+        value.encode(encoding, invalid: :replace, undef: :replace)
       end
 
       def message_from(response)

--- a/lib/active_merchant/billing/gateways/epsilon/epsilon_base.rb
+++ b/lib/active_merchant/billing/gateways/epsilon/epsilon_base.rb
@@ -68,7 +68,12 @@ module ActiveMerchant #:nodoc:
       end
 
       def post_data(parameters = {})
-        parameters.map { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
+        parameters.map { |k, v| "#{k}=#{CGI.escape(encode_value(v.to_s))}" }.join('&')
+      end
+
+      def encode_value(value)
+        return value unless @options[:encoding]
+        value.encode(@options[:encoding], invalid: :replace, undef: :replace)
       end
 
       def message_from(response)

--- a/lib/active_merchant/billing/gateways/epsilon/epsilon_base.rb
+++ b/lib/active_merchant/billing/gateways/epsilon/epsilon_base.rb
@@ -29,7 +29,7 @@ module ActiveMerchant #:nodoc:
 
       self.abstract_class = true
 
-      cattr_accessor :contract_code, :proxy_address, :proxy_port
+      cattr_accessor :contract_code, :proxy_address, :proxy_port, :encoding
 
       self.test_url            = 'https://beta.epsilon.jp/cgi-bin/order/'
       self.live_url            = 'https://secure.epsilon.jp/cgi-bin/order/'
@@ -72,8 +72,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def encode_value(value)
-        return value unless @options[:encoding]
-        value.encode(@options[:encoding], invalid: :replace, undef: :replace)
+        return value unless self.encoding
+        value.encode(self.encoding, invalid: :replace, undef: :replace)
       end
 
       def message_from(response)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,7 @@ require 'tapp'
 require 'vcr'
 
 require 'webmock/minitest'
+require 'mocha/mini_test'
 
 Dotenv.load
 

--- a/test/unit/gateways/epsilon_test.rb
+++ b/test/unit/gateways/epsilon_test.rb
@@ -12,7 +12,8 @@ class EpsilonGatewayTest < MiniTest::Test
   end
 
   def test_purchase_post_data_encoding_eucjp
-    gateway = ActiveMerchant::Billing::EpsilonGateway.new(encoding: Encoding::EUC_JP)
+    ActiveMerchant::Billing::EpsilonBaseGateway.encoding = Encoding::EUC_JP
+    gateway = ActiveMerchant::Billing::EpsilonGateway.new
     fixture = YAML.load_file('test/fixtures/vcr_cassettes/purchase_successful.yml')
     response_body = fixture['http_interactions'][0]['response']['body']['string']
     detail = {

--- a/test/unit/gateways/epsilon_test.rb
+++ b/test/unit/gateways/epsilon_test.rb
@@ -1,11 +1,33 @@
 require 'test_helper'
 
 class EpsilonGatewayTest < MiniTest::Test
+  include SamplePaymentMethods
+
   def test_set_proxy_address_and_port
     ActiveMerchant::Billing::EpsilonGateway.proxy_address = 'http://myproxy.dev'
     ActiveMerchant::Billing::EpsilonGateway.proxy_port = 1234
     gateway = ActiveMerchant::Billing::EpsilonGateway.new
     assert_equal(gateway.proxy_address, 'http://myproxy.dev')
     assert_equal(gateway.proxy_port, 1234)
+  end
+
+  def test_purchase_post_data_encoding_eucjp
+    gateway = ActiveMerchant::Billing::EpsilonGateway.new(encoding: Encoding::EUC_JP)
+    fixture = YAML.load_file('test/fixtures/vcr_cassettes/purchase_successful.yml')
+    response_body = fixture['http_interactions'][0]['response']['body']['string']
+    detail = {
+      user_name: '山田太郎',
+      item_name: 'すごい商品',
+      order_number: '12345678',
+    }
+    gateway.expects(:ssl_post).with(
+      instance_of(String),
+      all_of(
+        includes('user_name=%BB%B3%C5%C4%C2%C0%CF%BA'),
+        includes('item_name=%A4%B9%A4%B4%A4%A4%BE%A6%C9%CA'),
+        includes('order_number=12345678'),
+      )
+    ).returns(response_body)
+    gateway.purchase(100, valid_credit_card, detail)
   end
 end


### PR DESCRIPTION
According to the Epsilon specification, the request parameters must be encode in `EUC-JP` or `Shift_JIS`. For the specification, this pull request add `encoding` setting.

Usage:

```
ActiveMerchant::Billing::EpsilonBaseGateway.encoding = Encoding::EUC_JP
```

The default encoding value is nil, nothing is encoded.
