### PR TITLE
Send pay time params on registered purchase

### DIFF
--- a/lib/active_merchant/billing/gateways/epsilon.rb
+++ b/lib/active_merchant/billing/gateways/epsilon.rb
@@ -43,6 +43,8 @@ module ActiveMerchant #:nodoc:
           mission_code:  EpsilonMissionCode::PURCHASE,
           item_price:    amount,
           process_code:  2,
+          card_st_code:  detail[:credit_type],
+          pay_time:      detail[:payment_time],
           xml:           1,
         }
 

--- a/lib/active_merchant/epsilon/version.rb
+++ b/lib/active_merchant/epsilon/version.rb
@@ -1,5 +1,5 @@
 module ActiveMerchant
   module Epsilon
-    VERSION = "0.6.0"
+    VERSION = "0.7.0"
   end
 end

--- a/lib/active_merchant/epsilon/version.rb
+++ b/lib/active_merchant/epsilon/version.rb
@@ -1,5 +1,5 @@
 module ActiveMerchant
   module Epsilon
-    VERSION = "0.7.0"
+    VERSION = "0.6.0"
   end
 end


### PR DESCRIPTION
According to the specification, following parameters are accepted even if the payment is registered purchase.

- `card_st_code`
- `pay_time`
