### PR TITLE
bump up version0.8.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### 0.8.0
+* GMO IDに登録されているクレジットカードで決済できるようにしました。
+  * [GMO ID決済の機能を追加した by ryuchan00](https://github.com/pepabo/active_merchant-epsilon/pull/93) 
+
 ### 0.5.9
 
 * 都度課金、定期課金、コンビニ決済で memo1, memo2 を送信できるようにした #83

--- a/lib/active_merchant/epsilon/version.rb
+++ b/lib/active_merchant/epsilon/version.rb
@@ -1,5 +1,5 @@
 module ActiveMerchant
   module Epsilon
-    VERSION = "0.7.1"
+    VERSION = "0.8.0"
   end
 end


### PR DESCRIPTION
version0.8.0にあげます。

ref:
https://github.com/pepabo/active_merchant-epsilon/pull/93