### PR TITLE
オーダー情報確認に対応させる

### DIFF
--- a/lib/active_merchant/billing/gateways/epsilon.rb
+++ b/lib/active_merchant/billing/gateways/epsilon.rb
@@ -18,6 +18,7 @@ module ActiveMerchant #:nodoc:
         void:                    'cancel_payment.cgi',
         find_user:               'get_user_info.cgi',
         change_recurring_amount: 'change_amount_payment.cgi',
+        find_order:              'getsales2.cgi',
       }.freeze
 
       self.supported_cardtypes = [:visa, :master, :american_express, :discover]
@@ -162,6 +163,15 @@ module ActiveMerchant #:nodoc:
           r.process { purchase(1, credit_card, o) }
           r.process(:ignore_result) { void(o[:order_number]) }
         end
+      end
+
+      def find_order(order_number)
+        params = {
+          contract_code: self.contract_code,
+          order_number:  order_number,
+        }
+
+        commit(PATHS[:find_order], params)
       end
 
       private

--- a/lib/active_merchant/billing/gateways/epsilon.rb
+++ b/lib/active_merchant/billing/gateways/epsilon.rb
@@ -173,8 +173,6 @@ module ActiveMerchant #:nodoc:
 
         response_keys = [
           :transaction_code,
-          :error_code,
-          :error_detail,
           :state,
           :payment_code,
           :item_price,

--- a/lib/active_merchant/billing/gateways/epsilon.rb
+++ b/lib/active_merchant/billing/gateways/epsilon.rb
@@ -171,7 +171,16 @@ module ActiveMerchant #:nodoc:
           order_number:  order_number,
         }
 
-        commit(PATHS[:find_order], params)
+        response_keys = [
+          :transaction_code,
+          :error_code,
+          :error_detail,
+          :state,
+          :payment_code,
+          :item_price,
+        ]
+
+        commit(PATHS[:find_order], params, response_keys)
       end
 
       private

--- a/lib/active_merchant/billing/gateways/response_parser.rb
+++ b/lib/active_merchant/billing/gateways/response_parser.rb
@@ -81,6 +81,14 @@ module ActiveMerchant #:nodoc:
         @xml.xpath(ResponseXpath::STATE).to_s
       end
 
+      def payment_code
+        @xml.xpath(ResponseXpath::PAYMENT_CODE).to_s
+      end
+
+      def item_price
+        @xml.xpath(ResponseXpath::ITEM_PRICE).to_s
+      end
+
       def uri_decode(string)
         URI.decode(string).encode(Encoding::UTF_8, Encoding::CP932)
       end
@@ -101,6 +109,8 @@ module ActiveMerchant #:nodoc:
         CONVENIENCE_STORE_PAYMENT_SLIP_URL = '//Epsilon_result/result[@haraikomi_url][1]/@haraikomi_url'
         COMPANY_CODE                       = '//Epsilon_result/result[@kigyou_code][1]/@kigyou_code'
         STATE                              = '//Epsilon_result/result[@state]/@state'
+        ITEM_PRICE                         = '//Epsilon_result/result[@item_price]/@item_price'
+        PAYMENT_CODE                       = '//Epsilon_result/result[@payment_code]/@payment_code'
       end
 
       module ResultCode

--- a/lib/active_merchant/billing/gateways/response_parser.rb
+++ b/lib/active_merchant/billing/gateways/response_parser.rb
@@ -8,7 +8,7 @@ module ActiveMerchant #:nodoc:
         @result = @xml.xpath(ResponseXpath::RESULT).to_s
 
         response = {
-          success: [ResultCode::SUCCESS, ResultCode::THREE_D_SECURE].include?(@result),
+          success: [ResultCode::SUCCESS, ResultCode::THREE_D_SECURE].include?(@result) || !state.empty?,
           message: "#{error_code}: #{error_detail}"
         }
 
@@ -77,6 +77,10 @@ module ActiveMerchant #:nodoc:
         @xml.xpath(ResponseXpath::COMPANY_CODE).to_s
       end
 
+      def state
+        @xml.xpath(ResponseXpath::STATE).to_s
+      end
+
       def uri_decode(string)
         URI.decode(string).encode(Encoding::UTF_8, Encoding::CP932)
       end
@@ -96,6 +100,7 @@ module ActiveMerchant #:nodoc:
         CONVENIENCE_STORE_LIMIT_DATE       = '//Epsilon_result/result[@conveni_limit][1]/@conveni_limit'
         CONVENIENCE_STORE_PAYMENT_SLIP_URL = '//Epsilon_result/result[@haraikomi_url][1]/@haraikomi_url'
         COMPANY_CODE                       = '//Epsilon_result/result[@kigyou_code][1]/@kigyou_code'
+        STATE                              = '//Epsilon_result/result[@state]/@state'
       end
 
       module ResultCode

--- a/test/fixtures/vcr_cassettes/find_order_failure.yml
+++ b/test/fixtures/vcr_cassettes/find_order_failure.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://beta.epsilon.jp/cgi-bin/order/getsales2.cgi
+    body:
+      encoding: UTF-8
+      string: contract_code=[CONTRACT_CODE]&order_number=1234567890
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Jul 2018 01:17:41 GMT
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=UTF8
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"  ?>
+        <Epsilon_result>
+        </Epsilon_result>
+    http_version: 
+  recorded_at: Tue, 17 Jul 2018 01:17:38 GMT
+recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/find_order_success.yml
+++ b/test/fixtures/vcr_cassettes/find_order_success.yml
@@ -1,0 +1,106 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://beta.epsilon.jp/cgi-bin/order/direct_card_payment.cgi
+    body:
+      encoding: UTF-8
+      string: contract_code=[CONTRACT_CODE]&user_id=U1531791686&user_name=YAMADA+Taro&user_mail_add=yamada-taro%40example.com&item_code=ITEM001&item_name=Greate+Product&order_number=O26659000&st_code=10000-0000-0000&mission_code=1&item_price=100&process_code=1&card_number=4242424242424242&expire_y=2019&expire_m=10&card_st_code=&pay_time=&tds_check_code=&user_agent=ActiveMerchant%3A%3AEpsilon-0.8.1&memo1=memo1&memo2=memo2
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Jul 2018 01:41:26 GMT
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=CP932
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="x-sjis-cp932"?>
+        <Epsilon_result>
+          <result acsurl="" />
+          <result err_code="" />
+          <result err_detail="" />
+          <result kari_flag="0" />
+          <result pareq="" />
+          <result result="1" />
+          <result trans_code="738442" />
+        </Epsilon_result>
+    http_version: 
+  recorded_at: Tue, 17 Jul 2018 01:41:28 GMT
+- request:
+    method: post
+    uri: https://beta.epsilon.jp/cgi-bin/order/getsales2.cgi
+    body:
+      encoding: UTF-8
+      string: contract_code=[CONTRACT_CODE]&order_number=O26659000
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 17 Jul 2018 01:41:28 GMT
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=CP932
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="x-sjis-cp932" ?>
+        <Epsilon_result>
+          <result last_update="2018-07-17+10%3A41%3A27" />
+          <result user_mail_add="yamada-taro%40example.com" />
+          <result state="1" />
+          <result credit_time="2018-07-17+10%3A41%3A28" />
+          <result trans_code="738442" />
+          <result mission_code="1" />
+          <result credit_flag="0" />
+          <result item_price="100" />
+          <result payment_code="1" />
+          <result item_code="ITEM001" />
+          <result order_number="O26659000" />
+          <result st_code="10000-0000-00000-00000-00000-00000-00000" />
+          <result memo1="memo1" />
+          <result contract_code="[CONTRACT_CODE]" />
+          <result item_name="Greate+Product" />
+          <result pay_time="1" />
+          <result user_name="YAMADA+Taro" />
+          <result process_code="1" />
+          <result keitai="100" />
+          <result due_date="" />
+          <result card_st_code="10" />
+          <result add_info="" />
+          <result user_id="U1531791686" />
+          <result memo2="memo2" />
+        </Epsilon_result>
+    http_version: 
+  recorded_at: Tue, 17 Jul 2018 01:41:28 GMT
+recorded_with: VCR 4.0.0

--- a/test/remote/gateways/remote_epsilon_test.rb
+++ b/test/remote/gateways/remote_epsilon_test.rb
@@ -271,9 +271,9 @@ class RemoteEpsilonGatewayTest < MiniTest::Test
       response = gateway.find_order(detail[:order_number])
       assert_equal true, response.success?
 
-      assert_match /\A\d{1,2}\z/, response.params['state']
-      assert_match /\A\d{1,2}\z/, response.params['payment_code']
-      assert_match /\A\d+\z/, response.params['item_price']
+      assert_equal true, !response.params['state'].empty?
+      assert_equal true, !response.params['payment_code'].empty?
+      assert_equal true, !response.params['item_price'].empty?
     end
   end
 

--- a/test/remote/gateways/remote_epsilon_test.rb
+++ b/test/remote/gateways/remote_epsilon_test.rb
@@ -261,4 +261,23 @@ class RemoteEpsilonGatewayTest < MiniTest::Test
       assert_equal false, response.success?
     end
   end
+
+  def test_find_order_success
+    VCR.use_cassette(:find_order_success) do
+      detail = purchase_detail
+      purchase_response = gateway.purchase(100, valid_credit_card, detail)
+      assert_equal true, purchase_response.success?
+
+      response = gateway.find_order(detail[:order_number])
+      binding.pry
+      assert_equal true, response.success?
+    end
+  end
+
+  def test_find_order_failure
+    VCR.use_cassette(:find_order_failure) do
+      response = gateway.find_order('1234567890')
+      assert_equal false, response.success?
+    end
+  end
 end

--- a/test/remote/gateways/remote_epsilon_test.rb
+++ b/test/remote/gateways/remote_epsilon_test.rb
@@ -269,8 +269,11 @@ class RemoteEpsilonGatewayTest < MiniTest::Test
       assert_equal true, purchase_response.success?
 
       response = gateway.find_order(detail[:order_number])
-      binding.pry
       assert_equal true, response.success?
+
+      assert_match /\A\d{1,2}\z/, response.params['state']
+      assert_match /\A\d{1,2}\z/, response.params['payment_code']
+      assert_match /\A\d+\z/, response.params['item_price']
     end
   end
 


### PR DESCRIPTION
イプシロンにて決済したオーダーの情報を取得するAPIに対応させます。

ref: `CGI設定マニュアル 他通貨決済対応版 ver.3.0.20` p.71~73