### PR TITLE
オーダー情報確認で入金額を取得できるようにする

### DIFF
--- a/lib/active_merchant/billing/gateways/epsilon.rb
+++ b/lib/active_merchant/billing/gateways/epsilon.rb
@@ -176,6 +176,7 @@ module ActiveMerchant #:nodoc:
           :state,
           :payment_code,
           :item_price,
+          :amount,
         ]
 
         commit(PATHS[:find_order], params, response_keys)

--- a/lib/active_merchant/billing/gateways/response_parser.rb
+++ b/lib/active_merchant/billing/gateways/response_parser.rb
@@ -113,6 +113,10 @@ module ActiveMerchant #:nodoc:
         @xml.xpath(ResponseXpath::ITEM_PRICE).to_s
       end
 
+      def amount
+        @xml.xpath(ResponseXpath::AMOUNT).to_s
+      end
+
       def uri_decode(string)
         URI.decode(string).encode(Encoding::UTF_8, Encoding::CP932)
       end
@@ -141,6 +145,7 @@ module ActiveMerchant #:nodoc:
         STATE                              = '//Epsilon_result/result[@state]/@state'
         ITEM_PRICE                         = '//Epsilon_result/result[@item_price]/@item_price'
         PAYMENT_CODE                       = '//Epsilon_result/result[@payment_code]/@payment_code'
+        AMOUNT                             = '//Epsilon_result/result[@amount]/@amount'
       end
 
       module ResultCode


### PR DESCRIPTION
close: #96 

決済方法がバーチャル口座決済のオーダーは、口座情報の他に入金額も返すようになっているのでこれを取得できるようにします。

ref: `CGI設定マニュアル 他通貨決済対応版 ver.3.0.20` p.71~73