### PR TITLE
Fix use of the obsolete method

### DIFF
--- a/lib/active_merchant/billing/gateways/response_parser.rb
+++ b/lib/active_merchant/billing/gateways/response_parser.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class ResponseParser
@@ -118,7 +120,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def uri_decode(string)
-        URI.decode(string).encode(Encoding::UTF_8, Encoding::CP932)
+        CGI.unescape(string).encode(Encoding::UTF_8, Encoding::CP932)
       end
 
       module ResponseXpath


### PR DESCRIPTION
`URI.decode` is obsolete method. In this case, it is appropriate to use `CGI.unescape`.

https://docs.ruby-lang.org/en/latest/class/URI.html#S_DECODE