### PR TITLE
Update dependencies version

### DIFF
--- a/active_merchant-epsilon.gemspec
+++ b/active_merchant-epsilon.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activemerchant', '~> 1.88'
   spec.add_dependency 'nokogiri'
 
-  spec.add_development_dependency 'bundler', '~> 1.7'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'dotenv'
   spec.add_development_dependency 'pry-byebug'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake'
   spec.add_development_dependency 'tapp'
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'vcr'


### PR DESCRIPTION
There is no code that depends on a particular version. So, we use the latest version.