### PR TITLE
GMO後払い version 1 を使うようにする

### DIFF
--- a/lib/active_merchant/billing/gateways/epsilon_gmo_after.rb
+++ b/lib/active_merchant/billing/gateways/epsilon_gmo_after.rb
@@ -24,7 +24,6 @@ module ActiveMerchant #:nodoc:
           orderer_name: detail[:orderer_name],
           orderer_address: detail[:orderer_address],
           orderer_tel: detail[:orderer_tel],
-          version: 2, # 推奨文字コードがUTF8の方を指定
         }
 
         params[:memo1] = detail[:memo1] if detail.has_key?(:memo1)

--- a/lib/active_merchant/billing/gateways/epsilon_gmo_after.rb
+++ b/lib/active_merchant/billing/gateways/epsilon_gmo_after.rb
@@ -1,6 +1,11 @@
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class EpsilonGmoAfterGateway < EpsilonBaseGateway
+
+      RESPONSE_KEYS = DEFAULT_RESPONSE_KEYS + [
+        :redirect,
+      ]
+
       def purchase(amount, detail = {})
         params = {
           contract_code: self.contract_code,
@@ -30,7 +35,7 @@ module ActiveMerchant #:nodoc:
         params[:memo2] = detail[:memo2] if detail.has_key?(:memo2)
         params[:user_tel] = detail[:user_tel] if detail.has_key?(:user_tel)
 
-        commit('receive_order3.cgi', params, [:redirect])
+        commit('receive_order3.cgi', params, RESPONSE_KEYS)
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/response_parser.rb
+++ b/lib/active_merchant/billing/gateways/response_parser.rb
@@ -124,13 +124,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def uri_decode(string)
-        decoded_string = CGI.unescape(string)
-
-        unless decoded_string.encoding == Encoding::UTF_8
-          decoded_string = decoded_string.encode(Encoding::UTF_8, Encoding::CP932)
-        end
-
-        decoded_string
+        CGI.unescape(string).encode(Encoding::UTF_8, Encoding::CP932)
       end
 
       module ResponseXpath

--- a/test/fixtures/vcr_cassettes/gmo_after_purchase_fail.yml
+++ b/test/fixtures/vcr_cassettes/gmo_after_purchase_fail.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://beta.epsilon.jp/cgi-bin/order/receive_order3.cgi
     body:
       encoding: UTF-8
-      string: contract_code=[CONTRACT_CODE]&user_id=&user_name=YAMADA+Taro&user_mail_add=yamada-taro%40example.com&item_code=ITEM001&item_name=Greate+Product&order_number=O2665045&st_code=00000-0000-00000-00010-00000-00000-00000&mission_code=1&item_price=10000&process_code=1&xml=1&delivery_code=99&consignee_postal=1500002&consignee_name=%E3%82%A4%E3%83%97%E3%82%B7%E3%83%AD%E3%83%B3%E3%82%BF%E3%83%AD%E3%82%A6&consignee_address=%E6%9D%B1%E4%BA%AC%E9%83%BD%E6%B8%8B%E8%B0%B7%E5%8C%BA%EF%BC%91%E2%88%92%EF%BC%91%E2%88%92%EF%BC%91&consignee_tel=0312345678&orderer_postal=1500002&orderer_name=YAMADA+Taro&orderer_address=%E6%9D%B1%E4%BA%AC%E9%83%BD%E6%B8%8B%E8%B0%B7%E5%8C%BA1-1-1&orderer_tel=0312345678&version=2&memo1=memo1&memo2=memo2
+      string: contract_code=[CONTRACT_CODE]&user_id=&user_name=%E5%B1%B1%E7%94%B0+%E5%A4%AA%E9%83%8E&user_mail_add=yamada-taro%40example.com&item_code=ITEM001&item_name=Greate+Product&order_number=O666431&st_code=00000-0000-00000-00010-00000-00000-00000&mission_code=1&item_price=10000&process_code=1&xml=1&delivery_code=99&consignee_postal=1000001&consignee_name=%E3%82%A4%E3%83%97%E3%82%B7%E3%83%AD%E3%83%B3%E3%82%BF%E3%83%AD%E3%82%A6&consignee_address=%E6%9D%B1%E4%BA%AC%E9%83%BD%E5%8D%83%E4%BB%A3%E7%94%B0%E5%8C%BA%E5%8D%83%E4%BB%A3%E7%94%B01%E7%95%AA1%E5%8F%B7&consignee_tel=0312345678&orderer_postal=1000001&orderer_name=YAMADA+Taro&orderer_address=%E6%9D%B1%E4%BA%AC%E9%83%BD%E5%8D%83%E4%BB%A3%E7%94%B0%E5%8C%BA%E5%8D%83%E4%BB%A3%E7%94%B01%E7%95%AA1%E5%8F%B7&orderer_tel=0312345678&memo1=memo1&memo2=memo2&user_tel=0312345678
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 13 Mar 2020 02:42:03 GMT
+      - Wed, 18 Mar 2020 05:58:06 GMT
       Server:
       - Apache
       Connection:
@@ -36,9 +36,9 @@ http_interactions:
       encoding: UTF-8
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n  <Epsilon_result>\r\n
         \   <result result=\"0\" />\r\n    <result err_code=\"601\" />\r\n    <result
-        err_detail=\"%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BCID%E3%81%AE%E5%BD%A2%E5%BC%8F%E3%81%8C%E7%95%B0%E5%B8%B8%E3%81%A7%E3%81%99\"
+        err_detail=\"%83%86%81%5B%83U%81%5BID%82%CC%8C%60%8E%AE%82%AA%88%D9%8F%ED%82%C5%82%B7\"
         />\r\n    <result memo1=\"memo1\" />\r\n    <result memo2=\"memo2\" />\r\n
         \ </Epsilon_result>\r\n"
     http_version: null
-  recorded_at: Fri, 13 Mar 2020 02:42:04 GMT
+  recorded_at: Wed, 18 Mar 2020 05:58:07 GMT
 recorded_with: VCR 5.1.0

--- a/test/fixtures/vcr_cassettes/gmo_after_purchase_successful.yml
+++ b/test/fixtures/vcr_cassettes/gmo_after_purchase_successful.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://beta.epsilon.jp/cgi-bin/order/receive_order3.cgi
     body:
       encoding: UTF-8
-      string: contract_code=[CONTRACT_CODE]&user_id=U1584067324&user_name=YAMADA+Taro&user_mail_add=yamada-taro%40example.com&item_code=ITEM001&item_name=Greate+Product&order_number=O4628159&st_code=00000-0000-00000-00010-00000-00000-00000&mission_code=1&item_price=10000&process_code=1&xml=1&delivery_code=99&consignee_postal=1500002&consignee_name=%E3%82%A4%E3%83%97%E3%82%B7%E3%83%AD%E3%83%B3%E3%82%BF%E3%83%AD%E3%82%A6&consignee_address=%E6%9D%B1%E4%BA%AC%E9%83%BD%E6%B8%8B%E8%B0%B7%E5%8C%BA%EF%BC%91%E2%88%92%EF%BC%91%E2%88%92%EF%BC%91&consignee_tel=0312345678&orderer_postal=1500002&orderer_name=YAMADA+Taro&orderer_address=%E6%9D%B1%E4%BA%AC%E9%83%BD%E6%B8%8B%E8%B0%B7%E5%8C%BA1-1-1&orderer_tel=0312345678&version=2&memo1=memo1&memo2=memo2
+      string: contract_code=[CONTRACT_CODE]&user_id=U1584510803&user_name=%E5%B1%B1%E7%94%B0+%E5%A4%AA%E9%83%8E&user_mail_add=yamada-taro%40example.com&item_code=ITEM001&item_name=Greate+Product&order_number=O23603867&st_code=00000-0000-00000-00010-00000-00000-00000&mission_code=1&item_price=10000&process_code=1&xml=1&delivery_code=99&consignee_postal=1000001&consignee_name=%E3%82%A4%E3%83%97%E3%82%B7%E3%83%AD%E3%83%B3%E3%82%BF%E3%83%AD%E3%82%A6&consignee_address=%E6%9D%B1%E4%BA%AC%E9%83%BD%E5%8D%83%E4%BB%A3%E7%94%B0%E5%8C%BA%E5%8D%83%E4%BB%A3%E7%94%B01%E7%95%AA1%E5%8F%B7&consignee_tel=0312345678&orderer_postal=1000001&orderer_name=YAMADA+Taro&orderer_address=%E6%9D%B1%E4%BA%AC%E9%83%BD%E5%8D%83%E4%BB%A3%E7%94%B0%E5%8C%BA%E5%8D%83%E4%BB%A3%E7%94%B01%E7%95%AA1%E5%8F%B7&orderer_tel=0312345678&memo1=memo1&memo2=memo2&user_tel=0312345678
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 13 Mar 2020 02:42:05 GMT
+      - Wed, 18 Mar 2020 05:53:23 GMT
       Server:
       - Apache
       Connection:
@@ -38,8 +38,8 @@ http_interactions:
         <?xml version="1.0" encoding="UTF-8" ?>
          <Epsilon_result>
           <result result="1" />
-          <result redirect="https%3A%2F%2Fbeta.epsilon.jp%2Fcgi-bin%2Forder%2Fmethod_select3.cgi%3Ftrans_code%3DpShgPaOlX%252Fs55" />
+          <result redirect="https%3A%2F%2Fbeta.epsilon.jp%2Fcgi-bin%2Forder%2Fmethod_select3.cgi%3Ftrans_code%3DITL3uKDMlWg41" />
           </Epsilon_result>
     http_version: null
-  recorded_at: Fri, 13 Mar 2020 02:42:05 GMT
+  recorded_at: Wed, 18 Mar 2020 05:53:25 GMT
 recorded_with: VCR 5.1.0

--- a/test/remote/gateways/remote_epsilon_convenience_store_test.rb
+++ b/test/remote/gateways/remote_epsilon_convenience_store_test.rb
@@ -24,6 +24,7 @@ class RemoteEpsilonConvenienceStoreGatewayTest < MiniTest::Test
     VCR.use_cassette(:convenience_store_purchase_fail) do
       response = gateway.purchase(10000, invalid_convenience_store, purchase_detail)
       assert_equal false, response.success?
+      assert_equal true, response.params["error_detail"].valid_encoding?
     end
   end
 end

--- a/test/remote/gateways/remote_epsilon_gmo_after_test.rb
+++ b/test/remote/gateways/remote_epsilon_gmo_after_test.rb
@@ -24,6 +24,7 @@ class RemoteEpsilonGmoAfterGatewayTest < MiniTest::Test
       response = gateway.purchase(10000, invalid_purchase_detail)
 
       assert_equal false, response.success?
+      assert_equal true, response.params["error_detail"].valid_encoding?
     end
   end
 end

--- a/test/remote/gateways/remote_epsilon_gmo_id_test.rb
+++ b/test/remote/gateways/remote_epsilon_gmo_id_test.rb
@@ -20,6 +20,7 @@ class RemoteEpsilonGmoIdGatewayTest < MiniTest::Test
       detail = invalid_gmo_id_purchase_detail
       response = gateway.purchase(200, detail)
       assert_equal false, response.success?
+      assert_equal true, response.params["error_detail"].valid_encoding?
     end
   end
 

--- a/test/remote/gateways/remote_epsilon_test.rb
+++ b/test/remote/gateways/remote_epsilon_test.rb
@@ -76,6 +76,7 @@ class RemoteEpsilonGatewayTest < MiniTest::Test
     VCR.use_cassette(:purchase_fail) do
       response = gateway.purchase(10000, invalid_credit_card, purchase_detail)
       assert_equal false, response.success?
+      assert_equal true, response.params["error_detail"].valid_encoding?
     end
   end
 
@@ -138,6 +139,7 @@ class RemoteEpsilonGatewayTest < MiniTest::Test
       )
 
       assert_equal false, response.success?
+      assert_equal true, response.params["error_detail"].valid_encoding?
     end
   end
 
@@ -239,6 +241,7 @@ class RemoteEpsilonGatewayTest < MiniTest::Test
       invalid_purchase_detail[:user_id] = ''
       response = gateway.registered_purchase(10000, invalid_purchase_detail)
       assert_equal false, response.success?
+      assert_equal true, response.params["error_detail"].valid_encoding?
     end
   end
 

--- a/test/remote/gateways/remote_epsilon_virtual_account_test.rb
+++ b/test/remote/gateways/remote_epsilon_virtual_account_test.rb
@@ -31,6 +31,7 @@ class RemoteEpsilonVirtualAccountGatewayTest < MiniTest::Test
     VCR.use_cassette(:virtual_account_purchase_fail) do
       response = gateway.purchase(10000, invalid_purchase_detail)
       assert_equal false, response.success?
+      assert_equal true, response.params["error_detail"].valid_encoding?
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -210,20 +210,21 @@ module SamplePaymentMethods
     now = Time.now
     {
       user_id:      "U#{Time.now.to_i}",
-      user_name:    'YAMADA Taro',
+      user_name:    '山田 太郎',
       user_email:   'yamada-taro@example.com',
+      user_tel:     '0312345678',
       item_code:    'ITEM001',
       item_name:    'Greate Product',
       order_number: "O#{now.sec}#{now.usec}",
       memo1:        'memo1',
       memo2:        'memo2',
-      consignee_postal: '1500002',
+      consignee_postal: '1000001',
       consignee_name: 'イプシロンタロウ',
-      consignee_address: '東京都渋谷区１−１−１',
+      consignee_address: '東京都千代田区千代田1番1号',
       consignee_tel: '0312345678',
-      orderer_postal: '1500002',
+      orderer_postal: '1000001',
       orderer_name: 'YAMADA Taro',
-      orderer_address: '東京都渋谷区1-1-1',
+      orderer_address: '東京都千代田区千代田1番1号',
       orderer_tel: '0312345678',
     }
   end


### PR DESCRIPTION
## やったこと

- 他決済に揃えるため、GMO後払いでも version 1 を使うようにしました
- レスポンスの文字コード変換が適切に行われているかのテストを追加しました

参考：`イプシロン決済システム仕様書 Ver.1.0.41 p44, 45`