### PR TITLE
Capture authorized payments

### DIFF
--- a/lib/active_merchant/billing/gateways/epsilon.rb
+++ b/lib/active_merchant/billing/gateways/epsilon.rb
@@ -51,6 +51,7 @@ module ActiveMerchant #:nodoc:
 
         params[:memo1] = detail[:memo1] if detail.has_key?(:memo1)
         params[:memo2] = detail[:memo2] if detail.has_key?(:memo2)
+        params[:kari_flag] = detail[:capture] ? 2 : 1 if detail.has_key?(:capture)
 
         commit(PATHS[:registered_purchase], params)
       end
@@ -83,6 +84,7 @@ module ActiveMerchant #:nodoc:
 
         params[:memo1] = detail[:memo1] if detail.has_key?(:memo1)
         params[:memo2] = detail[:memo2] if detail.has_key?(:memo2)
+        params[:kari_flag] = detail[:capture] ? 2 : 1 if detail.has_key?(:capture)
 
         commit(PATHS[:registered_recurring], params)
       end
@@ -208,6 +210,7 @@ module ActiveMerchant #:nodoc:
 
         params[:memo1] = detail[:memo1] if detail.has_key?(:memo1)
         params[:memo2] = detail[:memo2] if detail.has_key?(:memo2)
+        params[:kari_flag] = detail[:capture] ? 2 : 1 if detail.has_key?(:capture)
 
         if detail.has_key?(:token)
           params[:token] = detail[:token]

--- a/lib/active_merchant/billing/gateways/epsilon.rb
+++ b/lib/active_merchant/billing/gateways/epsilon.rb
@@ -19,6 +19,7 @@ module ActiveMerchant #:nodoc:
         find_user:               'get_user_info.cgi',
         change_recurring_amount: 'change_amount_payment.cgi',
         find_order:              'getsales2.cgi',
+        capture:                 'sales_payment.cgi',
       }.freeze
 
       self.supported_cardtypes = [:visa, :master, :american_express, :discover]
@@ -182,6 +183,15 @@ module ActiveMerchant #:nodoc:
         ]
 
         commit(PATHS[:find_order], params, response_keys)
+      end
+
+      def capture(order_number)
+        params = {
+          contract_code: self.contract_code,
+          order_number:  order_number,
+        }
+
+        commit(PATHS[:capture], params)
       end
 
       private

--- a/lib/active_merchant/billing/gateways/epsilon/epsilon_base.rb
+++ b/lib/active_merchant/billing/gateways/epsilon/epsilon_base.rb
@@ -49,7 +49,8 @@ module ActiveMerchant #:nodoc:
         :acs_url,
         :pa_req,
         :receipt_number,
-        :receipt_date
+        :receipt_date,
+        :captured,
       ].freeze
 
       private

--- a/lib/active_merchant/billing/gateways/response_parser.rb
+++ b/lib/active_merchant/billing/gateways/response_parser.rb
@@ -123,6 +123,10 @@ module ActiveMerchant #:nodoc:
         uri_decode(@xml.xpath(ResponseXpath::REDIRECT).to_s)
       end
 
+      def captured
+        @xml.xpath(ResponseXpath::CAPTURED).to_s != '1'
+      end
+
       def uri_decode(string)
         CGI.unescape(string).encode(Encoding::UTF_8, Encoding::CP932)
       end
@@ -153,6 +157,7 @@ module ActiveMerchant #:nodoc:
         PAYMENT_CODE                       = '//Epsilon_result/result[@payment_code]/@payment_code'
         AMOUNT                             = '//Epsilon_result/result[@amount]/@amount'
         REDIRECT                           = '//Epsilon_result/result[@redirect]/@redirect'
+        CAPTURED                           = '//Epsilon_result/result[@kari_flag]/@kari_flag'
       end
 
       module ResultCode

--- a/test/fixtures/vcr_cassettes/capture_failure.yml
+++ b/test/fixtures/vcr_cassettes/capture_failure.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://beta.epsilon.jp/cgi-bin/order/sales_payment.cgi
+    body:
+      encoding: UTF-8
+      string: contract_code=[CONTRACT_CODE]&order_number=1234567890
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 12 Jun 2020 11:00:12 GMT
+      Server:
+      - Apache
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=CP932
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="x-sjis-cp932"?>
+        <Epsilon_result>
+          <result err_code="810" />
+          <result err_detail="%91%CE%8F%DB%8E%E6%88%F8%82%CD%82%A0%82%E8%82%DC%82%B9%82%F1" />
+          <result result="9" />
+        </Epsilon_result>
+  recorded_at: Fri, 12 Jun 2020 11:00:14 GMT
+recorded_with: VCR 6.0.0

--- a/test/fixtures/vcr_cassettes/capture_success.yml
+++ b/test/fixtures/vcr_cassettes/capture_success.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://beta.epsilon.jp/cgi-bin/order/sales_payment.cgi
+    body:
+      encoding: UTF-8
+      string: contract_code=[CONTRACT_CODE]&order_number=O14289569
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 12 Jun 2020 11:00:16 GMT
+      Server:
+      - Apache
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=CP932
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="x-sjis-cp932"?>
+        <Epsilon_result>
+          <result err_code="" />
+          <result err_detail="" />
+          <result result="1" />
+        </Epsilon_result>
+  recorded_at: Fri, 12 Jun 2020 11:00:17 GMT
+recorded_with: VCR 6.0.0

--- a/test/fixtures/vcr_cassettes/capture_success_authorize.yml
+++ b/test/fixtures/vcr_cassettes/capture_success_authorize.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://beta.epsilon.jp/cgi-bin/order/direct_card_payment.cgi
+    body:
+      encoding: UTF-8
+      string: contract_code=[CONTRACT_CODE]&user_id=U1591959614&user_name=YAMADA+Taro&user_mail_add=yamada-taro%40example.com&item_code=ITEM001&item_name=Greate+Product&order_number=O14289569&st_code=10000-0000-0000&mission_code=1&kari_flag=1&item_price=100&process_code=1&card_number=4242424242424242&expire_y=2021&expire_m=10&card_st_code=&pay_time=&tds_check_code=&user_agent=ActiveMerchant%3A%3AEpsilon-0.9.4&memo1=memo1&memo2=memo2
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 12 Jun 2020 11:00:15 GMT
+      Server:
+      - Apache
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=CP932
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="x-sjis-cp932"?>
+        <Epsilon_result>
+          <result acsurl="" />
+          <result err_code="" />
+          <result err_detail="" />
+          <result kari_flag="1" />
+          <result pareq="" />
+          <result result="1" />
+          <result trans_code="1362118" />
+        </Epsilon_result>
+  recorded_at: Fri, 12 Jun 2020 11:00:16 GMT
+recorded_with: VCR 6.0.0

--- a/test/fixtures/vcr_cassettes/purchase_with_capture_false_successful.yml
+++ b/test/fixtures/vcr_cassettes/purchase_with_capture_false_successful.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://beta.epsilon.jp/cgi-bin/order/direct_card_payment.cgi
+    body:
+      encoding: UTF-8
+      string: contract_code=[CONTRACT_CODE]&user_id=U1591960355&user_name=YAMADA+Taro&user_mail_add=yamada-taro%40example.com&item_code=ITEM001&item_name=Greate+Product&order_number=O35284193&st_code=10000-0000-0000&mission_code=1&item_price=1000&process_code=1&card_number=4242424242424242&expire_y=2021&expire_m=10&card_st_code=&pay_time=&tds_check_code=&user_agent=ActiveMerchant%3A%3AEpsilon-0.9.4&memo1=memo1&memo2=memo2&kari_flag=1
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 12 Jun 2020 11:12:35 GMT
+      Server:
+      - Apache
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=CP932
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="x-sjis-cp932"?>
+        <Epsilon_result>
+          <result acsurl="" />
+          <result err_code="" />
+          <result err_detail="" />
+          <result kari_flag="1" />
+          <result pareq="" />
+          <result result="1" />
+          <result trans_code="1362123" />
+        </Epsilon_result>
+  recorded_at: Fri, 12 Jun 2020 11:12:37 GMT
+recorded_with: VCR 6.0.0

--- a/test/fixtures/vcr_cassettes/purchase_with_capture_true_successful.yml
+++ b/test/fixtures/vcr_cassettes/purchase_with_capture_true_successful.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://beta.epsilon.jp/cgi-bin/order/direct_card_payment.cgi
+    body:
+      encoding: UTF-8
+      string: contract_code=[CONTRACT_CODE]&user_id=U1591960357&user_name=YAMADA+Taro&user_mail_add=yamada-taro%40example.com&item_code=ITEM001&item_name=Greate+Product&order_number=O37368550&st_code=10000-0000-0000&mission_code=1&item_price=1000&process_code=1&card_number=4242424242424242&expire_y=2021&expire_m=10&card_st_code=&pay_time=&tds_check_code=&user_agent=ActiveMerchant%3A%3AEpsilon-0.9.4&memo1=memo1&memo2=memo2&kari_flag=2
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 12 Jun 2020 11:12:37 GMT
+      Server:
+      - Apache
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=CP932
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="x-sjis-cp932"?>
+        <Epsilon_result>
+          <result acsurl="" />
+          <result err_code="" />
+          <result err_detail="" />
+          <result kari_flag="0" />
+          <result pareq="" />
+          <result result="1" />
+          <result trans_code="1362124" />
+        </Epsilon_result>
+  recorded_at: Fri, 12 Jun 2020 11:12:39 GMT
+recorded_with: VCR 6.0.0

--- a/test/remote/gateways/remote_epsilon_test.rb
+++ b/test/remote/gateways/remote_epsilon_test.rb
@@ -304,4 +304,27 @@ class RemoteEpsilonGatewayTest < MiniTest::Test
       assert_equal false, response.success?
     end
   end
+
+  def test_capture_success
+    detail = purchase_detail
+
+    VCR.use_cassette(:capture_success_authorize) do
+      purchase_response = gateway.purchase(100, valid_credit_card, detail.merge(capture: false))
+
+      assert_equal true, purchase_response.success?
+      assert_equal false, purchase_response.params['captured']
+    end
+
+    VCR.use_cassette(:capture_success) do
+      response = gateway.capture(detail[:order_number])
+      assert_equal true, response.success?
+    end
+  end
+
+  def test_capture_failure
+    VCR.use_cassette(:capture_failure) do
+      response = gateway.capture('1234567890')
+      assert_equal false, response.success?
+    end
+  end
 end

--- a/test/remote/gateways/remote_epsilon_test.rb
+++ b/test/remote/gateways/remote_epsilon_test.rb
@@ -72,6 +72,24 @@ class RemoteEpsilonGatewayTest < MiniTest::Test
     end
   end
 
+  def test_purchase_with_capture_true_successful
+    VCR.use_cassette(:purchase_with_capture_true_successful) do
+      response = gateway.purchase(1000, valid_credit_card, purchase_detail.merge(capture: true))
+
+      assert_equal true, response.success?
+      assert_equal true, response.params['captured']
+    end
+  end
+
+  def test_purchase_with_capture_false_successful
+    VCR.use_cassette(:purchase_with_capture_false_successful) do
+      response = gateway.purchase(1000, valid_credit_card, purchase_detail.merge(capture: false))
+
+      assert_equal true, response.success?
+      assert_equal false, response.params['captured']
+    end
+  end
+
   def test_purchase_fail
     VCR.use_cassette(:purchase_fail) do
       response = gateway.purchase(10000, invalid_credit_card, purchase_detail)


### PR DESCRIPTION
- Makes purchase methods accept `capture` flag.
  - This will be sent as `kari_flag` to specify capture or not.
  - If not given, the setting configured in epsilon dashboard is used.
- Implements `capture` method which captures authorized payments. 