### PR TITLE
Bump up version 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-### 0.10.1
+### 0.11.0
 
 - [Add void mehotd for Epsilon Link Payment](https://github.com/pepabo/active_merchant-epsilon/pull/114)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### 0.10.1
+
+- [Add void mehotd for Epsilon Link Payment](https://github.com/pepabo/active_merchant-epsilon/pull/114)
+
 ### 0.10.0
 
 * [Capture authorized payments](https://github.com/pepabo/active_merchant-epsilon/pull/112)

--- a/lib/active_merchant/epsilon/version.rb
+++ b/lib/active_merchant/epsilon/version.rb
@@ -1,5 +1,5 @@
 module ActiveMerchant
   module Epsilon
-    VERSION = "0.10.1"
+    VERSION = "0.11.0"
   end
 end

--- a/lib/active_merchant/epsilon/version.rb
+++ b/lib/active_merchant/epsilon/version.rb
@@ -1,5 +1,5 @@
 module ActiveMerchant
   module Epsilon
-    VERSION = "0.10.0"
+    VERSION = "0.10.1"
   end
 end


### PR DESCRIPTION
https://github.com/pepabo/active_merchant-epsilon/pull/114 でイプシロンリンクタイプ決済の取消しを行う `void` メソッドを追加しました。