### PR TITLE
Bump up version 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### 0.12.0
+
+- [Add Parameter `delivery_info_required` to purchase method for Epsilon Link Payment](https://github.com/pepabo/active_merchant-epsilon/pull/116)
+
 ### 0.11.0
 
 - [Add void mehotd for Epsilon Link Payment](https://github.com/pepabo/active_merchant-epsilon/pull/114)

--- a/lib/active_merchant/epsilon/version.rb
+++ b/lib/active_merchant/epsilon/version.rb
@@ -1,5 +1,5 @@
 module ActiveMerchant
   module Epsilon
-    VERSION = "0.11.0"
+    VERSION = "0.12.0"
   end
 end


### PR DESCRIPTION
イプシロンリンクタイプで決済を行う `purchase` メソッド利用時に、配送情報を送信するかどうかを引数に渡して選択できるようにしました。 https://github.com/pepabo/active_merchant-epsilon/pull/116 

後方互換性のある機能追加のため、マイナーバージョンを上げます。