### PR TITLE
オーダー情報確認CGIのレスポンスに注文日時を追加

### DIFF
--- a/lib/active_merchant/billing/gateways/epsilon.rb
+++ b/lib/active_merchant/billing/gateways/epsilon.rb
@@ -177,6 +177,7 @@ module ActiveMerchant #:nodoc:
         response_keys = [
           :transaction_code,
           :state,
+          :last_update,
           :payment_code,
           :item_price,
           :amount,

--- a/lib/active_merchant/billing/gateways/response_parser.rb
+++ b/lib/active_merchant/billing/gateways/response_parser.rb
@@ -107,6 +107,10 @@ module ActiveMerchant #:nodoc:
         @xml.xpath(ResponseXpath::STATE).to_s
       end
 
+      def last_update
+        @xml.xpath(ResponseXpath::LAST_UPDATE).to_s
+      end
+
       def payment_code
         @xml.xpath(ResponseXpath::PAYMENT_CODE).to_s
       end
@@ -153,6 +157,7 @@ module ActiveMerchant #:nodoc:
         BRANCH_CODE                        = '//Epsilon_result/result[@branch_code][1]/@branch_code'
         BRANCH_NAME                        = '//Epsilon_result/result[@branch_name][1]/@branch_name'
         STATE                              = '//Epsilon_result/result[@state]/@state'
+        LAST_UPDATE                        = '//Epsilon_result/result[@last_update]/@last_update'
         ITEM_PRICE                         = '//Epsilon_result/result[@item_price]/@item_price'
         PAYMENT_CODE                       = '//Epsilon_result/result[@payment_code]/@payment_code'
         AMOUNT                             = '//Epsilon_result/result[@amount]/@amount'

--- a/test/remote/gateways/remote_epsilon_test.rb
+++ b/test/remote/gateways/remote_epsilon_test.rb
@@ -293,6 +293,7 @@ class RemoteEpsilonGatewayTest < MiniTest::Test
       assert_equal true, response.success?
 
       assert_equal true, !response.params['state'].empty?
+      assert_equal true, !response.params['last_update'].empty?
       assert_equal true, !response.params['payment_code'].empty?
       assert_equal true, !response.params['item_price'].empty?
     end


### PR DESCRIPTION
オーダー情報確認CGIのレスポンスには注文日時（last_update）が含まれています。
注文日時にアクセスできた方が調査などの場面で便利であるため、レスポンスのパラメーターに注文日時（last_update）を追加しました。