### PR TITLE
クレジットカード決済を3Dセキュア2.0に対応する

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,57 @@ purchase_detail = {
 # (snip)
 ```
 
+### CreditCard Payment with 3D secure 2.0(with token)
+
+```ruby
+# 3D secure 2.0 does not have a test environment for epsilon
+ActiveMerchant::Billing::Base.mode = :production
+
+amount = 1000
+purchase_detail = {
+  user_id:                   'YOUR_APP_USER_IDENTIFIER',
+  user_name:                 '山田 太郎',
+  user_email:                'yamada-taro@example.com',
+  item_code:                 'ITEM001',
+  item_name:                 'Greate Product',
+  order_number:              'UNIQUE ORDER NUMBER',
+  three_d_secure_check_code: 1,
+  token:                     'CREDIT CARD TOKEN'
+  tds_flag:                  21 # 21 or 22
+  # optional:
+  #   add params for risk-based certification(billAddrCity etc...)
+}
+
+response = gateway.purchase(amount, ActiveMerchant::Billing::CreditCard.new, purchase_detail)
+
+if response.success?
+  if response.params['three_d_secure']
+    puts response.params['tds2_url']
+    puts response.params['pa_req']
+  else
+    # NOT 3D SECURE
+    puts "Successfully charged #{amount} yen as credit card payment(not 3D secure)"
+  end
+else
+  raise StandardError, response.message
+end
+
+# (The card holder identifies himself on credit card's page and comes back here)
+
+# AND SECOND REQUEST
+
+response = gateway.authenticate(
+  order_number:         'ORDER NUMBER',
+  three_d_secure_pares: 'PAYMENT AUTHENTICATION RESPONSE',
+)
+
+if response.success?
+  puts 'Successfully charged as credit card payment(3D secure 2.0)'
+else
+  raise StandardError, response.message
+end
+```
+
 ### CreditCard Revolving Payment
 
 ```ruby

--- a/lib/active_merchant/billing/gateways/epsilon.rb
+++ b/lib/active_merchant/billing/gateways/epsilon.rb
@@ -22,6 +22,20 @@ module ActiveMerchant #:nodoc:
         capture:                 'sales_payment.cgi',
       }.freeze
 
+      RISK_BASE_AUTH_PARAMS_KEYS = %i[
+        tds_flag billAddrCity billAddrCountry billAddrLine1 billAddrLine2 billAddrLine3
+        billAddrPostCode billAddrState shipAddrCity shipAddrCountry shipAddrLine1 shipAddrLine2
+        shipAddrLine3 shipAddrPostCode shipAddrState chAccAgeInd chAccChange
+        chAccChangeIndchAccDate chAccPwdChange chAccPwChangeInd nbPurchaseAccount paymentAccAge
+        paymentAccInd provisionAttemptsDay shipAddressUsage shipAddressUsageInd shipNameIndicator
+        suspiciousAccActivity txnActivityDay txnActivityYear threeDSReqAuthData threeDSReqAuthMethod
+        threeDSReqAuthTimestamp addrMatch cardholderName homePhone mobilePhone
+        workPhone challengeInd deliveryEmailAddress deliveryTimeframe giftCardAmount
+        giftCardCount preOrderDate preOrderPurchaseInd reorderItemsInd shipIndicator
+      ].freeze
+
+      THREE_D_SECURE_2_INDICATORS = [21, 22].freeze
+
       self.supported_cardtypes = [:visa, :master, :american_express, :discover]
 
       def purchase(amount, credit_card, detail = {})
@@ -29,7 +43,11 @@ module ActiveMerchant #:nodoc:
 
         params = billing_params(amount, credit_card, detail)
 
-        commit(PATHS[:purchase], params)
+        if three_d_secure_2?(detail)
+          params.merge!(detail.slice(*RISK_BASE_AUTH_PARAMS_KEYS).compact)
+        end
+
+        commit(PATHS[:registered_purchase], params)
       end
 
       def registered_purchase(amount, detail = {})
@@ -238,6 +256,10 @@ module ActiveMerchant #:nodoc:
         end
 
         params
+      end
+
+      def three_d_secure_2?(detail)
+        THREE_D_SECURE_2_INDICATORS.include?(detail[:tds_flag])
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/epsilon.rb
+++ b/lib/active_merchant/billing/gateways/epsilon.rb
@@ -72,6 +72,10 @@ module ActiveMerchant #:nodoc:
         params[:memo2] = detail[:memo2] if detail.has_key?(:memo2)
         params[:kari_flag] = detail[:capture] ? 2 : 1 if detail.has_key?(:capture)
 
+        if three_d_secure_2?(detail)
+          params.merge!(detail.slice(*RISK_BASE_AUTH_PARAMS_KEYS).compact)
+        end
+
         commit(PATHS[:registered_purchase], params)
       end
 

--- a/lib/active_merchant/billing/gateways/epsilon.rb
+++ b/lib/active_merchant/billing/gateways/epsilon.rb
@@ -47,7 +47,7 @@ module ActiveMerchant #:nodoc:
           params.merge!(detail.slice(*RISK_BASE_AUTH_PARAMS_KEYS).compact)
         end
 
-        commit(PATHS[:registered_purchase], params)
+        commit(PATHS[:purchase], params)
       end
 
       def registered_purchase(amount, detail = {})

--- a/lib/active_merchant/billing/gateways/epsilon/epsilon_base.rb
+++ b/lib/active_merchant/billing/gateways/epsilon/epsilon_base.rb
@@ -48,6 +48,7 @@ module ActiveMerchant #:nodoc:
         :three_d_secure,
         :acs_url,
         :pa_req,
+        :tds2_url,
         :receipt_number,
         :receipt_date,
         :captured,

--- a/lib/active_merchant/billing/gateways/response_parser.rb
+++ b/lib/active_merchant/billing/gateways/response_parser.rb
@@ -10,7 +10,7 @@ module ActiveMerchant #:nodoc:
         @result = @xml.xpath(ResponseXpath::RESULT).to_s
 
         response = {
-          success: [ResultCode::SUCCESS, ResultCode::THREE_D_SECURE].include?(@result) || !state.empty?,
+          success: [ResultCode::SUCCESS, ResultCode::THREE_D_SECURE_1, ResultCode::THREE_D_SECURE_2].include?(@result) || !state.empty?,
           message: "#{error_code}: #{error_detail}"
         }
 
@@ -48,7 +48,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def three_d_secure
-        @result == ResultCode::THREE_D_SECURE
+        [ResultCode::THREE_D_SECURE_1, ResultCode::THREE_D_SECURE_2].include?(@result)
       end
 
       def acs_url
@@ -57,6 +57,10 @@ module ActiveMerchant #:nodoc:
 
       def pa_req
         uri_decode(@xml.xpath(ResponseXpath::PA_REQ).to_s)
+      end
+
+      def tds2_url
+        uri_decode(@xml.xpath(ResponseXpath::TDS2_URL).to_s)
       end
 
       def receipt_number
@@ -145,6 +149,7 @@ module ActiveMerchant #:nodoc:
         CARD_EXPIRE                        = '//Epsilon_result/result[@card_expire]/@card_expire'
         ACS_URL                            = '//Epsilon_result/result[@acsurl]/@acsurl' # ACS (Access Control Server)
         PA_REQ                             = '//Epsilon_result/result[@pareq]/@pareq' # PAReq (payer authentication request)
+        TDS2_URL                           = '//Epsilon_result/result[@tds2_url]/@tds2_url'
         RECEIPT_NUMBER                     = '//Epsilon_result/result[@receipt_no][1]/@receipt_no'
         RECEIPT_DATE                       = '//Epsilon_result/result[@receipt_date][1]/@receipt_date'
         CONVENIENCE_STORE_LIMIT_DATE       = '//Epsilon_result/result[@conveni_limit][1]/@conveni_limit'
@@ -166,10 +171,11 @@ module ActiveMerchant #:nodoc:
       end
 
       module ResultCode
-        FAILURE        = '0'
-        SUCCESS        = '1'
-        THREE_D_SECURE = '5'
-        SYSTEM_ERROR   = '9'
+        FAILURE          = '0'
+        SUCCESS          = '1'
+        THREE_D_SECURE_1 = '5'
+        THREE_D_SECURE_2 = '6'
+        SYSTEM_ERROR     = '9'
       end
     end
   end

--- a/test/fixtures/vcr_cassettes/authenticate_with_three_d_secure_2_successful.yml
+++ b/test/fixtures/vcr_cassettes/authenticate_with_three_d_secure_2_successful.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://secure.epsilon.jp/cgi-bin/order/direct_card_payment.cgi
+    body:
+      encoding: UTF-8
+      string: contract_code=[CONTRACT_CODE]&order_number=O30189731&tds_check_code=2&tds_pares=dummy+pa_res
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 15 Sep 2022 08:09:38 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '161'
+      Connection:
+      - close
+      Content-Type:
+      - text/xml; charset=CP932
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        <?xml version="1.0" encoding="x-sjis-cp932"?>
+        <Epsilon_result>
+          <result acsurl="" />
+          <result err_code="" />
+          <result err_detail="" />
+          <result kari_flag="0" />
+          <result pareq="" />
+          <result result="1" />
+          <result trans_code="257072796" />
+        </Epsilon_result>
+  recorded_at: Thu, 15 Sep 2022 08:09:38 GMT
+recorded_with: VCR 6.1.0

--- a/test/fixtures/vcr_cassettes/purchase_with_three_d_secure_2_successful.yml
+++ b/test/fixtures/vcr_cassettes/purchase_with_three_d_secure_2_successful.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://secure.epsilon.jp/cgi-bin/order/direct_card_payment.cgi
+    body:
+      encoding: UTF-8
+      string: contract_code=[CONTRACT_CODE]&user_id=U1663229130&user_name=YAMADA+Taro&user_mail_add=yamada-taro%40example.com&item_code=ITEM001&item_name=Greate+Product&order_number=O30189731&st_code=10000-0000-0000&mission_code=1&item_price=1000&process_code=1&card_st_code=&pay_time=&tds_check_code=1&user_agent=ActiveMerchant%3A%3AEpsilon-0.13.0&token=03d4a2ce2f747c9223a4ead24888d0293ad26c06273e296f9faa0675f99a1ff7&security_code=&security_check=1&tds_flag=21
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 15 Sep 2022 08:05:30 GMT
+      Server:
+      - Apache
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '231'
+      Connection:
+      - close
+      Content-Type:
+      - text/xml; charset=CP932
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        <?xml version="1.0" encoding="x-sjis-cp932"?>
+        <Epsilon_result>
+          <result acsurl="" />
+          <result err_code="" />
+          <result err_detail="" />
+          <result pareq="TZ0SPvVKOob64%252BlXeutNUg79" />
+          <result result="6" />
+          <result tds2_url="https%3A%2F%2Fsecure.epsilon.jp%2Fcgi-bin%2Forder%2Ftds2.cgi" />
+          <result trans_code="257072796" />
+        </Epsilon_result>
+  recorded_at: Thu, 15 Sep 2022 08:05:31 GMT
+recorded_with: VCR 6.1.0

--- a/test/fixtures/vcr_cassettes/purchase_with_three_d_secure_2_successful.yml
+++ b/test/fixtures/vcr_cassettes/purchase_with_three_d_secure_2_successful.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://secure.epsilon.jp/cgi-bin/order/direct_card_payment.cgi
     body:
       encoding: UTF-8
-      string: contract_code=[CONTRACT_CODE]&user_id=U1663229130&user_name=YAMADA+Taro&user_mail_add=yamada-taro%40example.com&item_code=ITEM001&item_name=Greate+Product&order_number=O30189731&st_code=10000-0000-0000&mission_code=1&item_price=1000&process_code=1&card_st_code=&pay_time=&tds_check_code=1&user_agent=ActiveMerchant%3A%3AEpsilon-0.13.0&token=03d4a2ce2f747c9223a4ead24888d0293ad26c06273e296f9faa0675f99a1ff7&security_code=&security_check=1&tds_flag=21
+      string: contract_code=[CONTRACT_CODE]&user_id=124014051&user_name=YAMADA+TARO&user_mail_add=yamada-taro%40example.com&item_code=ITEM001&item_name=Greate+Product&order_number=O1663728963&st_code=10000-0000-0000&mission_code=1&item_price=1000&process_code=2&card_st_code=&pay_time=&xml=1&tds_flag=21
     headers:
       Content-Type:
       - application/x-www-form-urlencoded
@@ -23,13 +23,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 15 Sep 2022 08:05:30 GMT
+      - Wed, 21 Sep 2022 02:56:03 GMT
       Server:
       - Apache
       Vary:
       - Accept-Encoding
       Content-Length:
-      - '231'
+      - '234'
       Connection:
       - close
       Content-Type:
@@ -42,10 +42,10 @@ http_interactions:
           <result acsurl="" />
           <result err_code="" />
           <result err_detail="" />
-          <result pareq="TZ0SPvVKOob64%252BlXeutNUg79" />
+          <result pareq="sOuxTX%252BZHCDBJKRdKkN2Iw53" />
           <result result="6" />
           <result tds2_url="https%3A%2F%2Fsecure.epsilon.jp%2Fcgi-bin%2Forder%2Ftds2.cgi" />
-          <result trans_code="257072796" />
+          <result trans_code="257810878" />
         </Epsilon_result>
-  recorded_at: Thu, 15 Sep 2022 08:05:31 GMT
+  recorded_at: Wed, 21 Sep 2022 02:56:04 GMT
 recorded_with: VCR 6.1.0

--- a/test/remote/gateways/remote_epsilon_test.rb
+++ b/test/remote/gateways/remote_epsilon_test.rb
@@ -75,6 +75,34 @@ class RemoteEpsilonGatewayTest < MiniTest::Test
     end
   end
 
+  def test_purchase_with_three_d_secure_2_successful
+    # 3DS2.0はテスト環境がないので mode を :production にする
+    ActiveMerchant::Billing::Base.stub(:mode, :production) do
+      VCR.use_cassette(:purchase_with_three_d_secure_2_successful) do
+        response = gateway.purchase(
+          1000,
+          ActiveMerchant::Billing::CreditCard.new,
+          purchase_detail_for_three_d_secure_2
+        )
+
+        assert_equal true, response.success?
+        assert_equal true, response.params['three_d_secure']
+        assert_equal true, response.params['tds2_url'].present?
+        assert_equal true, response.params['pa_req'].present?
+        assert_empty response.params['acs_url']
+      end
+
+      VCR.use_cassette(:authenticate_with_three_d_secure_2_successful) do
+        response = gateway.authenticate(
+          order_number: purchase_detail_for_three_d_secure_2[:order_number],
+          three_d_secure_pa_res: 'dummy pa_res'
+        )
+
+        assert_equal true, response.success?
+      end
+    end
+  end
+
   def test_purchase_with_capture_true_successful
     VCR.use_cassette(:purchase_with_capture_true_successful) do
       response = gateway.purchase(1000, valid_credit_card, purchase_detail.merge(capture: true))

--- a/test/remote/gateways/remote_epsilon_test.rb
+++ b/test/remote/gateways/remote_epsilon_test.rb
@@ -287,9 +287,6 @@ class RemoteEpsilonGatewayTest < MiniTest::Test
   def test_registered_purchase_with_three_d_secure_2_successful
     # 3DS2.0はテスト環境がないので mode を :production にする
     ActiveMerchant::Billing::Base.stub(:mode, :production) do
-      # TODO: イプシロンのAPI改修が終わったらVCRカセットを取り直す
-      #   登録済み課金 + 3DS2.0の場合イプシロンのAPI側でエラーになり正常なレスポンスが返ってこない（2022/09/15時点）ので
-      #   接続先APIと期待するレスポンスが同じ purchase のVCRカセットを使用する
       VCR.use_cassette(:purchase_with_three_d_secure_2_successful) do
         response = gateway.registered_purchase(1000, purchase_detail_for_registered_and_three_d_secure_2)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -173,7 +173,7 @@ module SamplePaymentMethods
 
   def purchase_detail_for_registered_and_three_d_secure_2
     {
-      user_id:      'U1416470209',
+      user_id:      '124014051',
       user_email:   'yamada-taro@example.com',
       user_name:    'YAMADA TARO',
       item_code:    'ITEM001',

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -171,6 +171,18 @@ module SamplePaymentMethods
     }
   end
 
+  def purchase_detail_for_registered_and_three_d_secure_2
+    {
+      user_id:      'U1416470209',
+      user_email:   'yamada-taro@example.com',
+      user_name:    'YAMADA TARO',
+      item_code:    'ITEM001',
+      item_name:    'Greate Product',
+      order_number: "O#{Time.now.to_i}",
+      tds_flag:      21,
+    }
+  end
+
   def valid_three_d_secure_pa_res
     now = Time.now
     {

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -156,6 +156,21 @@ module SamplePaymentMethods
     }
   end
 
+  def purchase_detail_for_three_d_secure_2
+    now = Time.now
+    {
+      user_id:                   "U#{now.to_i}",
+      user_name:                 'YAMADA Taro',
+      user_email:                'yamada-taro@example.com',
+      item_code:                 'ITEM001',
+      item_name:                 'Greate Product',
+      order_number:              "O#{now.sec}#{now.usec}",
+      token:                     '03d4a2ce2f747c9223a4ead24888d0293ad26c06273e296f9faa0675f99a1ff7',
+      three_d_secure_check_code: 1,
+      tds_flag:                  21,
+    }
+  end
+
   def valid_three_d_secure_pa_res
     now = Time.now
     {


### PR DESCRIPTION
## 目的
3Dセキュア1.0は2022年10月13日に閉塞されるので、3Dセキュア2.0に対応できるようにします。
変更内容詳細や仕様書は[イプシロンからのお知らせ](https://www.epsilon.jp/news/20220726.html)にあります。

対応内容は以下です。

* 通常決済と登録済み課金の場合に3Dセキュア2.0に必要なパラメータを渡せるようにした
  * `purchase` と `registered_purchase` に対応
  * 月次課金（ `registered_recurring` ）は3Dセキュア対応のクレジットカードが利用できないので対応していない
* APIの改修が終わったので `registered_purchase` のテストも登録済み課金 + 3Dセキュア2.0用のVCRカセットを使用 ~`registered_purchase` のテストは一時的に他のVCRカセットを使って追加~ 
  * イプシロンのAPIに不具合があり、APIを叩いても正常なレスポンスが返ってこないので
  * 不具合が改修された後にVCRカセットを取り直す予定 => APIの改修が終わったのでVCRカセットを取り直した
* READMEに3Dセキュア2.0の場合を追加

