### PR TITLE
`actions/checkout@v3` を使う

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         ruby-version: [2.4, 2.5, 2.6, 2.7, 3.0]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: ruby/setup-ruby@v1.63.0
       with:


### PR DESCRIPTION
## 目的
* https://github.com/actions/checkout の最新版（ `@v3` ）を使うようにします
* `@v2` だとGitHub Actionsが実行されないという問題があるのでその対応です
  * ref: https://github.com/pepabo/active_merchant-epsilon/pull/121 