### PR TITLE
CIをトリガーする条件に pull_request を追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: test
-on: push
-
+on:
+  - push
+  - pull_request
 jobs:
   test-all:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,9 @@
 name: test
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   test-all:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要
- 「fork運用でPRを作成した際、CIの実行がApproveされても実行されない」という現象に対するPRです

## やったこと
- CI をトリガーするタイミングに on: pull_request を追加し、push に branches master 条件を追加
  - fork運用でPRを出した際にもCIがトリガーされる & 二重で CI がトリガーされないようにしています

## 関連
- https://github.com/pepabo/active_merchant-epsilon/pull/122
- https://github.com/pepabo/active_merchant-epsilon/pull/123