### PR TITLE
Bump up version 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### 0.14.0
+
+- [Support 3D Secure 2.0 for credit card payments](https://github.com/pepabo/active_merchant-epsilon/pull/121)
+
 ### 0.13.0
 
 - [Add `last-update` to OrderResponse](https://github.com/pepabo/active_merchant-epsilon/pull/118)

--- a/lib/active_merchant/epsilon/version.rb
+++ b/lib/active_merchant/epsilon/version.rb
@@ -1,5 +1,5 @@
 module ActiveMerchant
   module Epsilon
-    VERSION = "0.13.0"
+    VERSION = "0.14.0"
   end
 end


### PR DESCRIPTION
クレジットカード決済を3Dセキュア2.0に対応したのでバージョンを `0.14.0` に上げます。
https://github.com/pepabo/active_merchant-epsilon/pull/121