### PR TITLE
Update to Minitest 5.10+ and Upgrade Supported Ruby Versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.4, 2.5, 2.6, 2.7, 3.0]
+        ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4.0-preview1']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: ruby/setup-ruby@v1.63.0
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true

--- a/test/remote/gateways/remote_epsilon_convenience_store_test.rb
+++ b/test/remote/gateways/remote_epsilon_convenience_store_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RemoteEpsilonConvenienceStoreGatewayTest < MiniTest::Test
+class RemoteEpsilonConvenienceStoreGatewayTest < Minitest::Test
   include SamplePaymentMethods
 
   def gateway

--- a/test/remote/gateways/remote_epsilon_gmo_id_test.rb
+++ b/test/remote/gateways/remote_epsilon_gmo_id_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RemoteEpsilonGmoIdGatewayTest < MiniTest::Test
+class RemoteEpsilonGmoIdGatewayTest < Minitest::Test
   include SamplePaymentMethods
 
   def gateway

--- a/test/remote/gateways/remote_epsilon_link_payment_test.rb
+++ b/test/remote/gateways/remote_epsilon_link_payment_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-class RemoteEpsilonLinkPaymentTest < MiniTest::Test
+class RemoteEpsilonLinkPaymentTest < Minitest::Test
   include SamplePaymentMethods
 
   def gateway

--- a/test/remote/gateways/remote_epsilon_test.rb
+++ b/test/remote/gateways/remote_epsilon_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RemoteEpsilonGatewayTest < MiniTest::Test
+class RemoteEpsilonGatewayTest < Minitest::Test
   include SamplePaymentMethods
 
   def gateway

--- a/test/remote/gateways/remote_epsilon_virtual_account_test.rb
+++ b/test/remote/gateways/remote_epsilon_virtual_account_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RemoteEpsilonVirtualAccountGatewayTest < MiniTest::Test
+class RemoteEpsilonVirtualAccountGatewayTest < Minitest::Test
   include SamplePaymentMethods
 
   def gateway

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -69,7 +69,7 @@ module SamplePaymentMethods
       last_name:  'YAMADA',
       number:     '4123451111111117',
       month:      '12',
-      year:       '2023',
+      year:       Time.now.year + 1,
     )
   end
 

--- a/test/unit/billing/convenience_store_test.rb
+++ b/test/unit/billing/convenience_store_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class EpsilonConvenienceStoreTest < MiniTest::Test
+class EpsilonConvenienceStoreTest < Minitest::Test
   def test_blank_parameter_generate_error
     convenience_store = ActiveMerchant::Billing::ConvenienceStore.new(code: "",
                                                                       full_name_kana: "",

--- a/test/unit/gateways/epsilon_test.rb
+++ b/test/unit/gateways/epsilon_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class EpsilonGatewayTest < MiniTest::Test
+class EpsilonGatewayTest < Minitest::Test
   include SamplePaymentMethods
 
   def test_set_proxy_address_and_port


### PR DESCRIPTION
The MiniTest module is no longer working because the compatibility layer was removed in version 5.10, so I fixed it. I also corrected some tests that were failing due to hardcoding.

https://github.com/minitest/minitest/blob/master/History.rdoc#label-5.10.0+-2F+2016-11-30

And, increased the supported Ruby versions to include the latest stable releases.
