### PR TITLE
Support proxy settings with user and password

### DIFF
--- a/lib/active_merchant/billing/gateways/epsilon/epsilon_base.rb
+++ b/lib/active_merchant/billing/gateways/epsilon/epsilon_base.rb
@@ -29,7 +29,7 @@ module ActiveMerchant #:nodoc:
 
       self.abstract_class = true
 
-      cattr_accessor :contract_code, :proxy_address, :proxy_port, :encoding
+      cattr_accessor :contract_code, :proxy_address, :proxy_port, :proxy_user, :proxy_password, :encoding
 
       self.test_url            = 'https://beta.epsilon.jp/cgi-bin/order/'
       self.live_url            = 'https://secure.epsilon.jp/cgi-bin/order/'


### PR DESCRIPTION
Active Merchantにはプロキシ設定がありますが、ユーザーとパスワードを渡すことができません。そのため、Active Merchantはユーザー名・パスワードによる認証が必要なプロキシを利用できませんでした。

そこで以下のPull Requestにて、`ActiveMerchant::Connection`の`attr_accessor `として`:proxy_user`/`:proxy_password`を渡せるようにしました。
https://github.com/activemerchant/active_merchant/pull/5102

この`:proxy_user`/`:proxy_password`をactive_merchant-epsilonから利用できるようにします。
https://github.com/activemerchant/active_merchant/pull/5102 はマージはされましたがまだリリースされておらず、このPull Requestのマージタイミングについては相談したいです。

---

Active Merchant has proxy settings, but is unable to pass a user and password. Therefore, Active Merchant could not use authenticated proxies.

Therefore, the following Pull Request allows `:proxy_user`/`:proxy_password` to be passed as `attr_accessor ` of `ActiveMerchant::Connection`.
https://github.com/activemerchant/active_merchant/pull/5102

Make this `:proxy_user`/`:proxy_password` available to active_merchant-epsilon.

https://github.com/activemerchant/active_merchant/pull/5102 has been merged but not yet released, and we would like to discuss the merge timing of this Pull Request.