### PR TITLE
Fix argument name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ end
 # AND SECOND REQUEST
 
 response = gateway.authenticate(
-  order_number:         'ORDER NUMBER',
-  three_d_secure_pares: 'PAYMENT AUTHENTICATION RESPONSE',
+  order_number:          'ORDER NUMBER',
+  three_d_secure_pa_res: 'PAYMENT AUTHENTICATION RESPONSE',
 )
 
 if response.success?
@@ -199,8 +199,8 @@ end
 # AND SECOND REQUEST
 
 response = gateway.authenticate(
-  order_number:         'ORDER NUMBER',
-  three_d_secure_pares: 'PAYMENT AUTHENTICATION RESPONSE',
+  order_number:          'ORDER NUMBER',
+  three_d_secure_pa_res: 'PAYMENT AUTHENTICATION RESPONSE',
 )
 
 if response.success?


### PR DESCRIPTION
Looking at the code, the correct argument name is `three_d_secure_pa_res`, not `three_d_secure_pares`.
https://github.com/pepabo/active_merchant-epsilon/blob/e601e165c6b510f362ab686233098deee11a3039/lib/active_merchant/billing/gateways/epsilon.rb#L161

