### PR TITLE
find_order のレスポンスに sales_limit_exceeded_flag を追加

### DIFF
--- a/lib/active_merchant/billing/gateways/epsilon.rb
+++ b/lib/active_merchant/billing/gateways/epsilon.rb
@@ -189,6 +189,7 @@ module ActiveMerchant #:nodoc:
           :payment_code,
           :item_price,
           :amount,
+          :sales_limit_exceeded_flag,
         ]
 
         commit(PATHS[:find_order], params, response_keys)

--- a/lib/active_merchant/billing/gateways/response_parser.rb
+++ b/lib/active_merchant/billing/gateways/response_parser.rb
@@ -135,6 +135,10 @@ module ActiveMerchant #:nodoc:
         @xml.xpath(ResponseXpath::CAPTURED).to_s != '1'
       end
 
+      def sales_limit_exceeded_flag
+        @xml.xpath(ResponseXpath::SALES_LIMIT_EXCEEDED_FLAG).to_s
+      end
+
       def uri_decode(string)
         CGI.unescape(string).encode(Encoding::UTF_8, Encoding::CP932)
       end
@@ -168,6 +172,7 @@ module ActiveMerchant #:nodoc:
         AMOUNT                             = '//Epsilon_result/result[@amount]/@amount'
         REDIRECT                           = '//Epsilon_result/result[@redirect]/@redirect'
         CAPTURED                           = '//Epsilon_result/result[@kari_flag]/@kari_flag'
+        SALES_LIMIT_EXCEEDED_FLAG          = '//Epsilon_result/result[@sales_limit_exceeded_flag]/@sales_limit_exceeded_flag'
       end
 
       module ResultCode

--- a/test/fixtures/vcr_cassettes/find_order_success.yml
+++ b/test/fixtures/vcr_cassettes/find_order_success.yml
@@ -100,6 +100,7 @@ http_interactions:
           <result add_info="" />
           <result user_id="U1531791686" />
           <result memo2="memo2" />
+          <result sales_limit_exceeded_flag="0" />
         </Epsilon_result>
     http_version: 
   recorded_at: Tue, 17 Jul 2018 01:41:28 GMT

--- a/test/remote/gateways/remote_epsilon_test.rb
+++ b/test/remote/gateways/remote_epsilon_test.rb
@@ -351,6 +351,7 @@ class RemoteEpsilonGatewayTest < Minitest::Test
       assert_equal true, !response.params['last_update'].empty?
       assert_equal true, !response.params['payment_code'].empty?
       assert_equal true, !response.params['item_price'].empty?
+      assert_equal true, !response.params['sales_limit_exceeded_flag'].empty?
     end
   end
 


### PR DESCRIPTION
## 概要

`find_order` (getsales2.cgi) レスポンスに `sales_limit_exceeded_flag` を追加する。
このパラメータは取引が実売上可能期限を超過したかどうかを示す:

- `1`: 実売上可能期限超過
- `0`: 実売上可能期限内

## 背景

イプシロン決済で、仮売上有効期限を超過した取引を検知できるよう、本 gem の consumer から新規パラメータにアクセスできるようにする。

## 変更内容

- `SALES_LIMIT_EXCEEDED_FLAG` XPath 定数を追加
- `ResponseParser` に `sales_limit_exceeded_flag` accessor を追加
- `find_order` の `response_keys` に `:sales_limit_exceeded_flag` を追加
- `find_order_success` の VCR cassette に新規フィールドを追加
- `test_find_order_success` に assertion を追加

## Version bump

マージ後、0.16.0 の version bump (CHANGELOG + version.rb) を別 PR で対応する予定 (#131 → #132 と同じパターン)。