### PR TITLE
Fix 3D Secure test stub errors and update CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4.0-preview1']
+        ruby-version: ['3.1', '3.2', '3.3', '3.4']
 
     steps:
     - uses: actions/checkout@v2

--- a/active_merchant-epsilon.gemspec
+++ b/active_merchant-epsilon.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'dotenv'
+  spec.add_development_dependency 'minitest-mock'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'tapp'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 require 'minitest/autorun'
+require 'minitest/mock'
 
 require 'active_merchant'
 require 'active_merchant/epsilon'


### PR DESCRIPTION
## 概要

以下 2 つの CI 問題を修正する。

1. **minitest 6 で `minitest/mock` が本体から分離された影響で、`.stub` を使用する 3D Secure テストが失敗する問題**
2. **CI matrix の Ruby バージョン設定が古くなっている問題** (Ruby 3.0 EOL / Ruby 3.4.0-preview1 が runner に存在しない)

## 修正 1: minitest/mock 分離への対応

失敗していたテスト:
- `RemoteEpsilonGatewayTest#test_purchase_with_three_d_secure_2_successful`
- `RemoteEpsilonGatewayTest#test_registered_purchase_with_three_d_secure_2_successful`
- `RemoteEpsilonLinkPaymentTest#test_epsilon_link_type_with_3d_secure`

いずれも `NoMethodError: undefined method 'stub' for ActiveMerchant::Billing::Base:Module` で失敗。原因は minitest 6.x で `minitest/mock` が本体から切り出されて別 gem 化されたこと。

### 変更内容

- `active_merchant-epsilon.gemspec`: `minitest-mock` を development dependency に追加
- `test/test_helper.rb`: `require 'minitest/mock'` を追加

## 修正 2: CI matrix の Ruby バージョン更新

`.github/workflows/test.yml` の Ruby matrix を以下のとおり更新:

- **Before**: `['3.0', '3.1', '3.2', '3.3', '3.4.0-preview1']`
- **After**: `['3.1', '3.2', '3.3', '3.4']`

### 理由

- **Ruby 3.0**: EOL (2024-04) 済。追加した `minitest-mock` 5.x が `required_ruby_version >= 3.1` のため、Ruby 3.0 では bundle install が失敗する
- **Ruby 3.4.0-preview1**: Actions runner から提供停止 (`Unavailable version 3.4.0-preview1 for ubuntu-24.04`)。GA 済の Ruby 3.4 に置き換え

## 検証

Ruby 3.1.7 / 3.2.8 / 3.3.10 で local 実行して全 48 テスト pass を確認:

`48 runs, 114 assertions, 0 failures, 0 errors, 0 skips`

修正前は 3 errors (Ruby 3.2.8 でも) 発生していた。

## 経緯

#133 の CI で 3 つの 3D Secure テストが失敗していたが、`master` でも同じ失敗が発生していたため pre-existing の問題と判明。原因が minitest 6.x での `minitest/mock` 分離とわかったため、本 PR で修正する。加えて、初版で CI matrix の EOL Ruby / 存在しない preview 版に起因する追加失敗が判明したため matrix も更新した。