### PR TITLE
Release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### 0.16.0
+
+- [Add `sales_limit_exceeded_flag` to `find_order` response](https://github.com/pepabo/active_merchant-epsilon/pull/133)
+
 ### 0.15.0
 
 - [Support 3D Secure parameters for link type payments](https://github.com/pepabo/active_merchant-epsilon/pull/131)

--- a/lib/active_merchant/epsilon/version.rb
+++ b/lib/active_merchant/epsilon/version.rb
@@ -1,5 +1,5 @@
 module ActiveMerchant
   module Epsilon
-    VERSION = "0.15.0"
+    VERSION = "0.16.0"
   end
 end


### PR DESCRIPTION
## 概要

  `active_merchant-epsilon` v0.16.0 リリース。#133 (Add `sales_limit_exceeded_flag` to `find_order` response) を含む。

  ## 変更内容

  - `lib/active_merchant/epsilon/version.rb`: `0.15.0` → `0.16.0`
  - `CHANGELOG.md`: 0.16.0 エントリ追加

  ## リリース手順 (このPR マージ後)

  1. `git tag v0.16.0` → `git push origin v0.16.0`
  2. `gem build active_merchant-epsilon.gemspec`
  3. `gem push active_merchant-epsilon-0.16.0.gem` (rubygems.org owner 権限持ちが実行)

  ## 参考

  - #133 (feature PR、merged)