### PR TITLE
Trusted Publishing の仕組みをつかって Gem をリリースするためのワークフローを追加する

### DIFF
--- a/.github/workflows/gem_push.yml
+++ b/.github/workflows/gem_push.yml
@@ -1,0 +1,41 @@
+name: Publish gem to rubygems.org
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  push:
+    if: github.repository == 'pepabo/active_merchant-epsilon'
+    runs-on: ubuntu-latest
+
+    environment:
+      name: rubygems.org
+      url: https://rubygems.org/gems/active_merchant-epsilon
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      # Set up
+      - name: Harden Runner
+        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@fb404b9557c186e349162b0d8efb06e2bc36edea # v1.232.0
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      # Release
+      - name: Publish to RubyGems
+        uses: rubygems/release-gem@9e85cb11501bebc2ae661c1500176316d3987059 # v1


### PR DESCRIPTION
タグ切ったら gem push されたい。pepabo/oneaws#19 で導入済みの Trusted Publishing の仕組みを流用する。
導入後は tag push で自動リリースされる。事前に rubygems.org 側で Trusted Publisher の登録が必要。

ref:
pepabo/oneaws#19
https://guides.rubygems.org/trusted-publishing/adding-a-publisher/